### PR TITLE
Handle insufficient data after SMA calculation

### DIFF
--- a/alpha_core/market_analysis.py
+++ b/alpha_core/market_analysis.py
@@ -168,6 +168,12 @@ class BacktestEngine:
         df["sma_long"] = df["close"].rolling(long_window).mean()
         df.dropna(inplace=True)
 
+        if df.empty:
+            raise ValueError(
+                "Insufficient data after applying moving averages: "
+                f"requires at least {long_window} rows but got {len(df)} for {symbol}"
+            )
+
         df["position"] = np.where(df["sma_short"] > df["sma_long"], 1.0, 0.0)
         df["position_shifted"] = df["position"].shift(1).fillna(0.0)
         df["turnover"] = (df["position_shifted"] - df["position_shifted"].shift(1).fillna(0.0)).abs()


### PR DESCRIPTION
## Summary
- raise a clear error when the SMA backtest drops all rows after rolling windows
- include the required long-window length and available data length in the error message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd64b709ec8324b952e54db5f119e7